### PR TITLE
bugfix: disable response fail

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -227,8 +227,8 @@ const config = {
     },
     enableResponseFail: {
       $filter: 'env',
-      production: true,
-      $default: true,
+      production: false,
+      $default: false,
     },
     enableTextSearch: {
       $filter: 'env',


### PR DESCRIPTION
Disables response fail that prevents some response payloads from returning.

Still need to make sure response validation fails are still logging.