### PR TITLE
Updated tag schema to add segmentCount.  Created one-time script to u…

### DIFF
--- a/scripts/tag-segment-count.js
+++ b/scripts/tag-segment-count.js
@@ -1,0 +1,43 @@
+'use strict';
+
+process.env.NODE_ENV = 'local';
+const path = require('path');
+const Mongoose = require('mongoose');
+const RestHapi = require('rest-hapi');
+const Config = require('../config');
+const restHapiConfig = Config.get('/restHapiConfig');
+
+(async function processTags() {
+  RestHapi.config.loglevel = 'DEBUG';
+  const Log = RestHapi.getLogger('tag-segment-count.js');
+  try {
+    Mongoose.connect(restHapiConfig.mongo.URI);
+    RestHapi.config = restHapiConfig;
+    RestHapi.config.absoluteModelPath = true;
+    RestHapi.config.modelPath = path.join(__dirname, '/../server/models');
+    let models = await RestHapi.generateModels(Mongoose);
+
+    //DO WORK
+
+    const Tag = Mongoose.model('tag');
+    const tags = await RestHapi.list(Tag, { isDeleted: false, $embed: ['segments'] }, Log);
+
+    Log.log('Updating segment counts....');
+
+    for (let i = 0; i < tags.docs.length; i++) {
+      Log.log(tags.docs[i]._id, tags.docs[i].segments.length);
+      let tag = await RestHapi.update({
+        model: 'tag',
+        _id: tags.docs[i]._id.toString(),
+        payload: { segmentCount: tags.docs[i].segments.length },
+        Log: Log,
+      });
+    }
+
+    Log.log('SCRIPT DONE!');
+    process.exit(0);
+  } catch (err) {
+    Log.error(err);
+    process.exit(1);
+  }
+})();

--- a/server/models/tag.model.js
+++ b/server/models/tag.model.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(mongoose) {
+module.exports = function (mongoose) {
   var modelName = 'tag';
   var Types = mongoose.Schema.Types;
   var Schema = new mongoose.Schema(
@@ -9,6 +9,10 @@ module.exports = function(mongoose) {
         type: Types.String,
         required: true,
         unique: true,
+      },
+      segmentCount: {
+        type: Types.Number,
+        unique: false,
       },
     },
     { collection: modelName }


### PR DESCRIPTION
This is the first change I checked in on October 26.  It updates tag-model to add segmentCount, and contains a one-time script to update this value for existing tags.  Note that the code updates to track segmentCount as editing is done are not complete yet, so if run now the update script will need to be re-run once these updates are complete.  Review and test now if you wish, or wait until the editing code changes are complete.