### PR TITLE
Merge tags

### DIFF
--- a/scripts/tag-merge.js
+++ b/scripts/tag-merge.js
@@ -1,0 +1,113 @@
+'use strict';
+
+process.env.NODE_ENV = 'local';
+const path = require('path');
+const Mongoose = require('mongoose');
+const RestHapi = require('rest-hapi');
+const Config = require('../config');
+const restHapiConfig = Config.get('/restHapiConfig');
+const Manifest = require('../config/manifest.conf');
+const Glue = require('@hapi/glue');
+const _ = require('lodash');
+
+(async function processTags() {
+  RestHapi.config.loglevel = 'LOG';
+  const Log = RestHapi.getLogger('tag-merge.js');
+  try {
+    Mongoose.connect(restHapiConfig.mongo.URI);
+    RestHapi.config = restHapiConfig;
+    RestHapi.config.absoluteModelPath = true;
+    RestHapi.config.modelPath = path.join(__dirname, '/../server/models');
+    let models = await RestHapi.generateModels(Mongoose);
+
+    const USER_ROLES = Config.get('/constants/USER_ROLES');
+
+    //DO WORK
+
+    const videos = await RestHapi.list({
+      model: 'video',
+      query: { $embed: ['segments.tags'] },
+    });
+
+    const manifest = Manifest.get('/');
+    const composeOptions = {
+      relativeTo: path.join(__dirname, '/../'),
+    };
+    const server = await Glue.compose(manifest, composeOptions);
+    await server.start();
+
+    for (let i = 0; i < 10; i++) {
+      //videos.docs.length
+      let video = videos.docs[i];
+      Log.log('video: ', video.title);
+      if (video.segments.length < 1) continue;
+      let updatedSegments = [];
+      for (let j = 0; j < video.segments.length; j++) {
+        const segment = videos.docs[i].segments[j];
+        Log.log('segment: ', segment.title);
+        let updatedSegment = {
+          segmentId: segment.segmentId,
+          video: video._id.toString(),
+          start: segment.start,
+          end: segment.end,
+          title: segment.title,
+          description: segment.description,
+          pristine: false,
+        };
+        let updatedTags = [];
+        for (let k = 0; k < segment.tags.length; k++) {
+          let tag = segment.tags[k];
+          if (tag.tag.isDeleted == true) continue;
+          const oldTagName = tag.tag.name;
+          const newTagName = standardizeTag(oldTagName);
+          Log.log('Old tagname: ', oldTagName);
+          Log.log('New tagname: ', newTagName);
+          let updatedTag = {
+            rank: tag.rank,
+            tag: { name: newTagName },
+          };
+          updatedTags.push(updatedTag);
+        } //tag
+        updatedSegment.tags = updatedTags;
+        updatedSegments.push(updatedSegment);
+      } //segment
+
+      let updatePayload = {
+        videoId: video.ytId,
+        segments: updatedSegments,
+      };
+      let request = {
+        method: 'POST',
+        url: '/update-video-segments',
+        params: {},
+        query: {},
+        payload: updatePayload,
+        credentials: { scope: ['root', USER_ROLES.SUPER_ADMIN] },
+        headers: { authorization: 'Bearer' },
+      };
+      //let injectOptions = RestHapi.testHelper.mockInjection(request);
+      //Log.log('Calling update-video-segments API');
+      //let result = await server.inject(injectOptions);
+      //Log.log('API call status code:', result.statusCode);
+    } //video
+
+    Log.log('SCRIPT DONE!');
+    process.exit(0);
+  } catch (err) {
+    Log.error(err);
+    process.exit(1);
+  }
+})();
+
+function standardizeTag(name) {
+  //Eliminate leading and trailing spaces
+  name = name.trim();
+
+  //Eliminate junk characters at beginning
+  if (name.startsWith('#') || name.startsWith('$') || name.startsWith('.')) name = name.substr(1);
+
+  //Convert everything to lower case
+  name = name.toLowerCase();
+
+  return name;
+}

--- a/scripts/tag-merge.js
+++ b/scripts/tag-merge.js
@@ -99,3 +99,8 @@ const _ = require('lodash');
     process.exit(1);
   }
 })();
+
+// merge stats for 05/31/21:
+// tags before merge: 15712
+// tags after merge: 14447
+// tags merged: 1265

--- a/scripts/tag-merge.js
+++ b/scripts/tag-merge.js
@@ -36,8 +36,7 @@ const _ = require('lodash');
     const server = await Glue.compose(manifest, composeOptions);
     await server.start();
 
-    for (let i = 0; i < 10; i++) {
-      //videos.docs.length
+    for (let i = 0; i < videos.docs.length; i++) {
       let video = videos.docs[i];
       Log.log('video: ', video.title);
       if (video.segments.length < 1) continue;
@@ -85,10 +84,10 @@ const _ = require('lodash');
         credentials: { scope: ['root', USER_ROLES.SUPER_ADMIN] },
         headers: { authorization: 'Bearer' },
       };
-      //let injectOptions = RestHapi.testHelper.mockInjection(request);
-      //Log.log('Calling update-video-segments API');
-      //let result = await server.inject(injectOptions);
-      //Log.log('API call status code:', result.statusCode);
+      let injectOptions = RestHapi.testHelper.mockInjection(request);
+      Log.log('Calling update-video-segments API');
+      let result = await server.inject(injectOptions);
+      Log.log('API call status code:', result.statusCode);
     } //video
 
     Log.log('SCRIPT DONE!');

--- a/scripts/tag-merge.js
+++ b/scripts/tag-merge.js
@@ -108,8 +108,3 @@ const _ = require('lodash');
     process.exit(1);
   }
 })();
-
-// merge stats for 05/31/21:
-// tags before merge: 15712
-// tags after merge: 14447
-// tags merged: 1265

--- a/scripts/tag-merge.js
+++ b/scripts/tag-merge.js
@@ -20,6 +20,8 @@ const _ = require('lodash');
     RestHapi.config.modelPath = path.join(__dirname, '/../server/models');
     let models = await RestHapi.generateModels(Mongoose);
 
+    const Tag = Mongoose.model('tag');
+
     const USER_ROLES = Config.get('/constants/USER_ROLES');
 
     //DO WORK
@@ -56,9 +58,9 @@ const _ = require('lodash');
         let updatedTags = [];
         for (let k = 0; k < segment.tags.length; k++) {
           let tag = segment.tags[k];
-          if (tag.tag.isDeleted == true) continue;
+          if (!tag.tag || tag.tag.isDeleted == true) continue;
           const oldTagName = tag.tag.name;
-          const newTagName = standardizeTag(oldTagName);
+          const newTagName = Tag.standardizeTag(oldTagName);
           Log.log('Old tagname: ', oldTagName);
           Log.log('New tagname: ', newTagName);
           let updatedTag = {
@@ -97,16 +99,3 @@ const _ = require('lodash');
     process.exit(1);
   }
 })();
-
-function standardizeTag(name) {
-  //Eliminate leading and trailing spaces
-  name = name.trim();
-
-  //Eliminate junk characters at beginning
-  if (name.startsWith('#') || name.startsWith('$') || name.startsWith('.')) name = name.substr(1);
-
-  //Convert everything to lower case
-  name = name.toLowerCase();
-
-  return name;
-}

--- a/server/models/segment.model.js
+++ b/server/models/segment.model.js
@@ -94,6 +94,10 @@ module.exports = function (mongoose) {
         return a.tag.name === b.tag.name && a.rank === b.rank;
       };
 
+      // Filter out "ghost" tags (not sure how this occurs)
+      oldTags = oldTags.filter((t) => t.tag !== null);
+      currentTags = currentTags.filter((t) => t.tag !== null);
+
       const deletedTags = _.differenceBy(oldTags, currentTags, 'tag.name');
       const newTags = _.differenceWith(currentTags, oldTags, nameAndRank);
 

--- a/server/models/segment.model.js
+++ b/server/models/segment.model.js
@@ -170,6 +170,30 @@ module.exports = function (mongoose) {
           payload: { segmentCount: allTagsToCountSegmentsFor[i].segments.length },
         });
       }
+
+      //Delete orphan tags
+      const possibleOrphanTags = (
+        await RestHapi.list({
+          model: 'tag',
+          query: {
+            _id: tagsToRemove.map((t) => t.toString()),
+            isDeleted: false,
+            $embed: ['segments'],
+          },
+        })
+      ).docs;
+      //console.log('possibleOrphanTags:', possibleOrphanTags);
+      for (let i = 0; i < possibleOrphanTags.length; i++) {
+        //console.log(possibleOrphanTags[i]._id, possibleOrphanTags[i].segments.length);
+        if (possibleOrphanTags[i].segments.length < 1) {
+          //console.log('Deleting orphan tag: ', possibleOrphanTags[i]._id.toString());
+          await RestHapi.deleteOne({
+            model: 'tag',
+            _id: possibleOrphanTags[i]._id.toString(),
+            restCall: true,
+          });
+        }
+      }
     },
   };
 

--- a/server/models/segment.model.js
+++ b/server/models/segment.model.js
@@ -193,7 +193,6 @@ module.exports = function (mongoose) {
             model: 'tag',
             _id: possibleOrphanTags[i]._id.toString(),
             hardDelete: true,
-            restCall: true,
           });
         }
       }

--- a/server/models/segment.model.js
+++ b/server/models/segment.model.js
@@ -187,14 +187,12 @@ module.exports = function (mongoose) {
           },
         })
       ).docs;
-      //console.log('possibleOrphanTags:', possibleOrphanTags);
       for (let i = 0; i < possibleOrphanTags.length; i++) {
-        //console.log(possibleOrphanTags[i]._id, possibleOrphanTags[i].segments.length);
         if (possibleOrphanTags[i].segments.length < 1) {
-          //console.log('Deleting orphan tag: ', possibleOrphanTags[i]._id.toString());
           await RestHapi.deleteOne({
             model: 'tag',
             _id: possibleOrphanTags[i]._id.toString(),
+            hardDelete: true,
             restCall: true,
           });
         }


### PR DESCRIPTION
tag-merge.js is ready to run to clean up tags.  I tested that some sample tags were updated correctly in my local copy of the database (old tags with different capitalization now have no associated segments, normalized tags have count including these).  However, I am unable to test by running a search against my local database since search must use AWS service.  I would recommend doing some searches of common tags before and after running this merge program so any problems can be caught and the backup reverted before much additional data gets entered. 